### PR TITLE
Allow option to set cgroup in lxc container configs

### DIFF
--- a/lxc/driver.go
+++ b/lxc/driver.go
@@ -91,6 +91,7 @@ var (
 		"network_mode":   hclspec.NewAttr("network_mode", "string", false),
 		"command":        hclspec.NewAttr("command", "list(string)", false),
 		"environment":    hclspec.NewAttr("environment", "list(string)", false),
+		"cgroup":	  hclspec.NewAttr("cgroup", "string", false),
 		"portmap":        hclspec.NewAttr("portmap", "list(map(number))", false),
 	})
 
@@ -173,6 +174,7 @@ type TaskConfig struct {
 	DefaultConfig        string         `codec:"default_config"`
 	Command              []string       `codec:"command"`
 	Environment          []string       `codec:"environment"`
+	Cgroup	             string         `codec:"cgroup"`
 	PortMap              map[string]int `codec:"portmap"`
 }
 

--- a/lxc/lxc.go
+++ b/lxc/lxc.go
@@ -77,6 +77,9 @@ func (d *Driver) initializeContainer(cfg *drivers.TaskConfig, taskConfig TaskCon
 		return nil, err
 	}
 
+	// set cgroup dir
+	c.SetConfigItem("lxc.cgroup.dir", taskConfig.Cgroup)
+
 	// set environment
 	for _, env := range taskConfig.Environment {
 		c.SetConfigItem("lxc.environment", env)


### PR DESCRIPTION
start up container in a designated cgroup
/var/lib/lxc/container-name/config will contain the option lxc.cgroup.dir = <your-cgroup-here>

configure via nomad specification as key, value = "cgroup", "your-cgroup-here"